### PR TITLE
fix: persist strict mode mistakes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -410,8 +410,8 @@ onReady(() => {
 
   // Snapshot on user edit
   api.boardEl.addEventListener('cell-change', () => {
-    // clear mistake highlights on edit
-    [...api.boardEl.children].forEach((el) => el.classList.remove('mistake'));
+    // Re-evaluate board to keep strict mistake highlights in sync
+    if (solutionGrid) api.setSolution(solutionGrid);
     pushHistoryFromCurrent();
     // detect solved
     checkSolved(true);


### PR DESCRIPTION
## Summary
- keep strict-mode error highlighting by re-evaluating board after cell edits
- remove blanket clearing of mistake classes so wrong digits stay red

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run format:check` *(fails: Code style issues in src/ui.js)*

------
https://chatgpt.com/codex/tasks/task_b_68bdd5450a98832b8998af3a3e495670