### PR TITLE
fix: persist strict mode mistakes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -410,8 +410,8 @@ onReady(() => {
 
   // Snapshot on user edit
   api.boardEl.addEventListener('cell-change', () => {
-    // clear mistake highlights on edit
-    [...api.boardEl.children].forEach((el) => el.classList.remove('mistake'));
+    // Re-evaluate board to keep strict mistake highlights in sync
+    if (solutionGrid) api.setSolution(solutionGrid);
     pushHistoryFromCurrent();
     // detect solved
     checkSolved(true);

--- a/src/ui.js
+++ b/src/ui.js
@@ -20,14 +20,14 @@ function createCell(r, c) {
         c = Number(cell.dataset.col);
       if (!strictAccept(cell, digit)) {
         input.readOnly = false;
-        cell.classList.add(/*'mistake'*/'invalid');
+        cell.classList.add('mistake');
         flashError(cell);
         cell.dispatchEvent(
           new CustomEvent('strict-error', { bubbles: true, detail: { idx: r * 9 + c, digit } })
         );
       } else {
         input.readOnly = true;
-        cell.classList.remove(/*'mistake'*/'invalid');
+        cell.classList.remove('mistake');
         cell.classList.add('prefill');
         pulse(cell);
       }
@@ -237,7 +237,7 @@ export function initUI(root) {
         // keep wrong value in red, editable
         input.value = val;
         input.readOnly = false;
-        cell.classList.add(/*'mistake'*/'invalid');
+        cell.classList.add('mistake');
         updateHasValue(cell);
         flashError(cell);
         recomputeValidity();
@@ -254,7 +254,7 @@ export function initUI(root) {
       } else {
         input.value = val;
         input.readOnly = true;
-        cell.classList.remove(/*'mistake'*/'invalid');
+        cell.classList.remove('mistake');
         cell.classList.add('prefill');
         updateHasValue(cell);
         pulse(cell);
@@ -315,7 +315,7 @@ export function initUI(root) {
         // keep wrong digit visible (red), editable
         input.value = key;
         input.readOnly = false;
-        cell.classList.add(/*'mistake'*/'invalid');
+        cell.classList.add('mistake');
         updateHasValue(cell);
         flashError(cell);
         recomputeValidity();


### PR DESCRIPTION
## Summary
- keep strict-mode error highlighting by re-evaluating board after cell edits
- use `mistake` class for strict-mode mismatches
- format ui.js so Prettier check passes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_b_68bdd5450a98832b8998af3a3e495670