### PR TITLE
Fix mobile overflow and iOS input zoom (prevent jumping)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -462,7 +462,7 @@ main {
   text-align: center;
   font-family: var(--ui-font);
   font-weight: 700;
-  font-size: calc((var(--cell-size) - 12px) * 0.6);
+  font-size: max(16px, calc((var(--cell-size) - 12px) * 0.6));
   font-variant-numeric: tabular-nums;
   -webkit-font-smoothing: antialiased;
   border: 0;
@@ -473,7 +473,7 @@ main {
 /* Keep givens slightly smaller so they never clash with separators */
 .board .cell.prefill input,
 .board .cell.given input {
-  font-size: calc((var(--cell-size) - 10px) * 0.58);
+  font-size: max(16px, calc((var(--cell-size) - 10px) * 0.58));
 }
 /* Force board to never exceed available viewport (accounts for safe-area + padding) */
 /* consolidated into the final .board override (bottom-most wins) */
@@ -496,6 +496,16 @@ main {
 /* ===== layout fixes: center board and avoid scrollbar overlap ===== */
 html {
   scrollbar-gutter: auto;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+  min-height: 100svh;
+  overscroll-behavior: none;
 }
 
 .app {


### PR DESCRIPTION
### Motivation
- The board could exceed the viewport width on some phones and allowed overscroll which caused horizontal overflow and layout jumping when touched. 
- iOS Safari zooms inputs smaller than ~16px on focus which produced the noticeable “jump” when tapping cells. 
- The goal is to stabilize the root/layout and ensure cell inputs are large enough to avoid automatic zoom behavior.

### Description
- Constrain root layout by adding `html { width: 100%; max-width: 100%; overflow-x: hidden; }` and `body { max-width: 100%; overflow-x: hidden; min-height: 100svh; overscroll-behavior: none; }` to prevent horizontal overflow and overscroll. 
- Enforce a minimum readable font size for board inputs by changing `.board .cell input` and `.board .cell.prefill input, .board .cell.given input` to use `font-size: max(16px, calc(...))`, avoiding iOS input zoom. 
- All edits are contained to `styles.css` and keep the responsive sizing calculations while preventing layout shift on narrow viewports.

### Testing
- Launched a local server with `python -m http.server` and ran a headless Playwright smoke test that loaded `index.html` at a mobile-like viewport (`820x1180`) and saved a screenshot, which completed successfully. 
- Pre-commit formatting tasks (Prettier) ran as part of the commit hook and completed successfully. 
- No unit tests were present or required for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984bd439678832b9af946fb494b5814)